### PR TITLE
Update EXT-X-I-FRAME-STREAM-INF to draft 23

### DIFF
--- a/LiveStreamParser/LSPTag.h
+++ b/LiveStreamParser/LSPTag.h
@@ -598,15 +598,6 @@ typedef NS_ENUM(NSInteger, LSPMediaType) {
 @property (nonatomic, readonly) CGSize resolution;
 
 /**
- Maximum frame rate for all video in the variant stream.
- 
- Rounded to 3 decimal places. Should be present if video is ever >30fps
- 
- Not required. Will be zero if not present in attributes.
- */
-@property (nonatomic, readonly) double frameRate;
-
-/**
  Identifies media playlist file.
  */
 @property (nonatomic, readonly, nullable) NSURL *uri;

--- a/LiveStreamParser/LSPTag.m
+++ b/LiveStreamParser/LSPTag.m
@@ -450,7 +450,6 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
                                 @"AVERAGE-BANDWIDTH": @(LSPAttributeTypeDecimalInteger),
                                 @"CODECS": @(LSPAttributeTypeQuotedString),
                                 @"RESOLUTION": @(LSPAttributeTypeDecimalResolution),
-                                @"FRAME-RATE": @(LSPAttributeTypeDecimalFloatingPoint),
                                 @"URI": @(LSPAttributeTypeQuotedString)};
     });
     return [attributeTypeForKey[key] integerValue];
@@ -489,11 +488,6 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
         _resolution = CGSizeZero;
     }
     
-    NSNumber *frameRate = attributes[@"FRAME-RATE"];
-    if ([frameRate isKindOfClass:[NSNumber class]]) {
-        _frameRate = [frameRate doubleValue];
-    }
-    
     NSString *uriString = attributes[@"URI"];
     if ([uriString isKindOfClass:[NSString class]]) {
         NSURL *uri = [NSURL URLWithString:uriString];
@@ -505,7 +499,7 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
 
 + (nonnull NSArray<NSString *> *)attributeKeys
 {
-    return @[@"BANDWIDTH", @"AVERAGE-BANDWIDTH", @"CODECS", @"RESOLUTION", @"FRAME-RATE", @"URI"];
+    return @[@"BANDWIDTH", @"AVERAGE-BANDWIDTH", @"CODECS", @"RESOLUTION", @"URI"];
 }
 
 - (nullable NSString *)valueStringForAttributeKey:(nonnull NSString *)key
@@ -524,10 +518,6 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
     
     if ([key isEqualToString:@"RESOLUTION"]) {
         return [NSString stringWithFormat:@"%@x%@", @(self.resolution.width), @(self.resolution.height)];
-    }
-    
-    if ([key isEqualToString:@"FRAME-RATE"]) {
-        return [NSString stringWithFormat:@"%@", @(self.frameRate)];
     }
     
     if ([key isEqualToString:@"URI"]) {
@@ -582,10 +572,6 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
         return NO;
     }
     
-    if (self.frameRate != other.frameRate) {
-        return NO;
-    }
-    
     if (!LSPEqualObjects(self.uri, other.uri)) {
         return NO;
     }
@@ -595,7 +581,7 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
 
 - (NSUInteger)hash
 {
-    return [self.name hash] ^ _bandwidth ^ _averageBandwidth ^ [_codecs hash] ^ (NSUInteger)_resolution.width ^ (NSUInteger)_resolution.height ^ (NSUInteger)_frameRate ^ [_uri hash];
+    return [self.name hash] ^ _bandwidth ^ _averageBandwidth ^ [_codecs hash] ^ (NSUInteger)_resolution.width ^ (NSUInteger)_resolution.height ^ [_uri hash];
 }
 
 @end

--- a/LiveStreamParser/LSPTag.m
+++ b/LiveStreamParser/LSPTag.m
@@ -494,6 +494,12 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
         _frameRate = [frameRate doubleValue];
     }
     
+    NSString *uriString = attributes[@"URI"];
+    if ([uriString isKindOfClass:[NSString class]]) {
+        NSURL *uri = [NSURL URLWithString:uriString];
+        _uri = uri;
+    }
+    
     return self;
 }
 
@@ -501,7 +507,6 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
 {
     return @[@"BANDWIDTH", @"AVERAGE-BANDWIDTH", @"CODECS", @"RESOLUTION", @"FRAME-RATE", @"URI"];
 }
-
 
 - (nullable NSString *)valueStringForAttributeKey:(nonnull NSString *)key
 {
@@ -523,6 +528,10 @@ static inline BOOL LSPEqualObjects(id<NSObject>obj1, id<NSObject>obj2)
     
     if ([key isEqualToString:@"FRAME-RATE"]) {
         return [NSString stringWithFormat:@"%@", @(self.frameRate)];
+    }
+    
+    if ([key isEqualToString:@"URI"]) {
+        return LSPQuotedString([self.uri absoluteString]);
     }
     
     return nil;

--- a/LiveStreamParserTests/TagTests.m
+++ b/LiveStreamParserTests/TagTests.m
@@ -355,27 +355,14 @@
     XCTAssert(CGSizeEqualToSize(infoTag.resolution, testSize));
 }
 
-- (void)testFrameRate
-{
-    LSPIFrameStreamInfoTag *infoTag =[[LSPIFrameStreamInfoTag alloc] initWithAttributes:@{@"BANDWIDTH" : @1}];
-    XCTAssertEqual(infoTag.frameRate, (NSUInteger)0, @"When no framerate is present, value should be zero since we're not indicating a missing value otherwise");
-    
-    infoTag = [[LSPIFrameStreamInfoTag alloc] initWithAttributes:@{@"BANDWIDTH" : @1, @"FRAME-RATE":@24}];
-    XCTAssertEqual(infoTag.frameRate, (double)24);
-    
-    infoTag = [[LSPIFrameStreamInfoTag alloc] initWithAttributes:@{@"BANDWIDTH" : @1, @"FRAME-RATE":@65}];
-    XCTAssertEqual(infoTag.frameRate, (double)65);
-}
-
 - (void)testSerialization
 {
     LSPIFrameStreamInfoTag *tag = [[LSPIFrameStreamInfoTag alloc] initWithAttributes:@{@"BANDWIDTH" : @1,
                                                                                        @"AVERAGE-BANDWIDTH":@9876,
                                                                                        @"CODECS":@"a,b,c",
                                                                                        @"RESOLUTION":[NSValue valueWithCGSize:CGSizeMake(123, 456)],
-                                                                                       @"FRAME-RATE":@(28.1),
                                                                                        }];
-    NSString *expectedTag = @"#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1,AVERAGE-BANDWIDTH=9876,CODECS=\"a,b,c\",RESOLUTION=123x456,FRAME-RATE=28.1";
+    NSString *expectedTag = @"#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1,AVERAGE-BANDWIDTH=9876,CODECS=\"a,b,c\",RESOLUTION=123x456";
     XCTAssertEqualObjects([tag serialize], expectedTag);
 }
 
@@ -385,13 +372,11 @@
                                                                                         @"AVERAGE-BANDWIDTH":@9876,
                                                                                         @"CODECS":@"a,b,c",
                                                                                         @"RESOLUTION":[NSValue valueWithCGSize:CGSizeMake(123, 456)],
-                                                                                        @"FRAME-RATE":@(28.1),
                                                                                         }];
     LSPIFrameStreamInfoTag *tag2 = [[LSPIFrameStreamInfoTag alloc] initWithAttributes:@{@"BANDWIDTH" : @1,
                                                                                         @"AVERAGE-BANDWIDTH":@9876,
                                                                                         @"CODECS":@"a,b,c",
                                                                                         @"RESOLUTION":[NSValue valueWithCGSize:CGSizeMake(123, 456)],
-                                                                                        @"FRAME-RATE":@(28.1),
                                                                                         }];
     XCTAssertEqualObjects(tag1, tag2);
     
@@ -399,7 +384,6 @@
                                                                                         @"AVERAGE-BANDWIDTH":@9876,
                                                                                         @"CODECS":@"a,b,c",
                                                                                         @"RESOLUTION":[NSValue valueWithCGSize:CGSizeMake(123, 456)],
-                                                                                        @"FRAME-RATE":@(28.1),
                                                                                         }];
     
     XCTAssertNotEqualObjects(tag3, tag1);


### PR DESCRIPTION
* Remove `FRAMERATE` attribute from `EXT-X-I-FRAME-STREAM-INF` (#8)
* Fix missing `URI` handling on `EXT-X-I-FRAME-STREAM-INF` (fixes #4)